### PR TITLE
Create the player inventory

### DIFF
--- a/scenes/characters/player/player.gd
+++ b/scenes/characters/player/player.gd
@@ -3,12 +3,16 @@ extends Node2D
 
 @onready var _movement_component = $TileBasedMovementComponent
 var _player_state_loader: PlayerStateLoader
+var _inventory: Inventory
 
 func _ready() -> void:
 	_player_state_loader = MockPlayerStateLoader.new()
 	add_child(_player_state_loader)
 	
 	_movement_component.init(self)
+	
+	_inventory = Inventory.new()
+	_inventory.load_items(["magic wand"])
 
 func _physics_process(delta: float) -> void:
 	_movement_component.process_movement(delta)
@@ -17,3 +21,6 @@ func _process(delta: float) -> void:
 	if Input.is_action_just_pressed("test_api"):
 		var result = await _player_state_loader.load_player_state()
 		print(result)
+
+func has_item(item: String) -> bool:
+	return _inventory.has_item(item)

--- a/scenes/characters/player/player.tscn
+++ b/scenes/characters/player/player.tscn
@@ -1,33 +1,33 @@
-[gd_scene load_steps=5 format=3 uid="uid://c2rwri4onoggv"]
+[gd_scene format=3 uid="uid://c2rwri4onoggv"]
 
 [ext_resource type="Texture2D" uid="uid://dhr7p80drba8r" path="res://assets/Eris Esra's Character Template 4.0/16x16/16x16 Idle-Sheet.png" id="1_4krpc"]
-[ext_resource type="Script" path="res://scenes/characters/player/player.gd" id="1_d5o5k"]
-[ext_resource type="Script" path="res://scenes/components/tile_based_movement_component.gd" id="2_pt8ch"]
+[ext_resource type="Script" uid="uid://uh4i80ratblj" path="res://scenes/characters/player/player.gd" id="1_d5o5k"]
+[ext_resource type="Script" uid="uid://tvpaynvh3a4c" path="res://scenes/components/tile_based_movement_component.gd" id="2_pt8ch"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vqa02"]
 size = Vector2(16, 16)
 
-[node name="Player" type="Node2D"]
+[node name="Player" type="Node2D" unique_id=902991634]
 script = ExtResource("1_d5o5k")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=466841590]
 texture = ExtResource("1_4krpc")
 centered = false
 offset = Vector2(-2, -4)
 hframes = 4
 vframes = 5
 
-[node name="TileBasedMovementComponent" type="CharacterBody2D" parent="."]
+[node name="TileBasedMovementComponent" type="CharacterBody2D" parent="." unique_id=926794285]
 script = ExtResource("2_pt8ch")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="TileBasedMovementComponent"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TileBasedMovementComponent" unique_id=1316950446]
 position = Vector2(8, 8)
 shape = SubResource("RectangleShape2D_vqa02")
 
-[node name="RayCast2D" type="RayCast2D" parent="TileBasedMovementComponent"]
+[node name="RayCast2D" type="RayCast2D" parent="TileBasedMovementComponent" unique_id=2066792928]
 position = Vector2(8, 8)
 target_position = Vector2(0, 8)
 
-[node name="Camera2D" type="Camera2D" parent="."]
+[node name="Camera2D" type="Camera2D" parent="." unique_id=1182303739]
 position = Vector2(8, 8)
 zoom = Vector2(3, 3)

--- a/scenes/scripts/inventory.gd
+++ b/scenes/scripts/inventory.gd
@@ -1,0 +1,30 @@
+class_name Inventory
+extends RefCounted
+
+const _VALID_ITEMS = ["magic wand", "door key"]
+const _MAX_SIZE = 4
+
+var _items: Array = []
+
+func load_items(items: Array[String]):
+	_items.clear()
+	for item in items:
+		if len(_items) >= _MAX_SIZE:
+			break
+		var valid_item = _validate_item(item)
+		if valid_item == null:
+			continue
+		_items.append(valid_item)
+
+
+func read_items(items: Array):
+	return _items
+
+func has_item(item) -> bool:
+	return item in _items
+
+func _validate_item(item: String):
+	# For now items are strings and handle validation here
+	if item.to_lower() in _VALID_ITEMS:
+		return item
+	return null

--- a/scenes/scripts/inventory.gd.uid
+++ b/scenes/scripts/inventory.gd.uid
@@ -1,0 +1,1 @@
+uid://eh7kgan6espa


### PR DESCRIPTION
Inventory inherits from RefCounted, and is used to load and unload the player inventory.

Items are currently stored as a string, but can be refactored to be of a custom type.
Item validation is done within the inventory class for now, and the valid items are stored as a constant.
This is easily modifiable in the event the item implementation is changed.

Items are loaded and fetched as string values. In the future, it can be loaded from string and fetched as an item class.

Closes #9 