### PR TITLE
Feature: Add Item Sub-Menu + Refactoring

### DIFF
--- a/scenes/menu.gd
+++ b/scenes/menu.gd
@@ -1,12 +1,17 @@
-extends Node2D
+extends CanvasLayer
 
-@onready var select_arrow = $Control/MenuBanner/TextureRect
-@onready var menu = $Control
+signal status_menu_selected(hp: int, atk: int, def: int)
+signal status_menu_closed
+signal item_menu_selected(item1: String, item2: String, item3: String)
+signal item_menu_closed
 
-var _camera: Camera2D
+@onready var select_arrow = $MainMenu/MenuBanner/TextureRect
+@onready var menu = $MainMenu
+@onready var _stats_sub_menu = $StatsSubMenu
+@onready var _items_sub_menu = $ItemsSubMenu
+
 var _movement_component: TileBasedMovementComponent
 var _player: Player
-var _stats_sub_menu: Node = null
 
 enum MenuState { NOTHING, MENU, ITEM_SCREEN, STATUS_SCREEN }
 var menu_state: MenuState = MenuState.NOTHING
@@ -14,60 +19,55 @@ var menu_state: MenuState = MenuState.NOTHING
 enum MenuOptions {STATUS = 0, ITEM = 1, SYNC = 2, EXIT = 3}
 
 @onready var selected_option: int = MenuOptions.STATUS
-@onready var number_menu_options: int = ($Control/MenuBanner/TextContainer).get_child_count()
+@onready var number_menu_options: int = ($MainMenu/MenuBanner/TextContainer).get_child_count()
 
 const menu_start_offset_y = 7
 const menu_next_item_offset_y = 14
 
 func calculate_arrow_position() -> void:
 	var new_arrow_position: int = menu_start_offset_y + (selected_option % number_menu_options) * menu_next_item_offset_y
-	select_arrow.set_position(Vector2(6.0, new_arrow_position))
+	select_arrow.set_position(Vector2(8.0, new_arrow_position))
 
 func _ready() -> void:
 	menu.visible = false
 	calculate_arrow_position()
-	_camera = get_viewport().get_camera_2d()
 	_player = get_tree().get_first_node_in_group("player_group")
 	if _player:
 		_movement_component = _player.get_node("TileBasedMovementComponent")
-
-func _process(_delta: float) -> void:
-	if _camera:
-		global_position = _camera.global_position
-
-func _fade_to_black_then(callback: Callable) -> void:
-	var canvas = CanvasLayer.new()
-	var rect = ColorRect.new()
-	rect.color = Color.BLACK
-	rect.modulate = Color(1, 1, 1, 0)
-	rect.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	canvas.add_child(rect)
-	add_child(canvas)
-	var tween = create_tween()
-	tween.tween_property(rect, "modulate:a", 1.0, 0.5)
-	tween.tween_callback(callback)
+	status_menu_selected.connect(_stats_sub_menu._on_status_menu_selected)
+	status_menu_closed.connect(_stats_sub_menu._on_status_menu_closed)
+	item_menu_selected.connect(_items_sub_menu._on_item_menu_selected)
+	item_menu_closed.connect(_items_sub_menu._on_item_menu_closed)
 
 func _open_status_screen() -> void:
 	menu.visible = false
-	_stats_sub_menu = load("res://scenes/ui/stats_sub_menu.tscn").instantiate()
-	add_child(_stats_sub_menu)
 	menu_state = MenuState.STATUS_SCREEN
+	if _player:
+		var state = _player.get_player_state()
+		status_menu_selected.emit(int(state.stats.x), int(state.stats.y), int(state.stats.z))
 
 func _open_item_screen() -> void:
-	_fade_to_black_then(func():
-		GameManager.scene_controller.overlay_2d_scene("res://scenes/ui/item_screen_menu.tscn")
-		menu.visible = false
-		menu_state = MenuState.ITEM_SCREEN
-	)
+	menu.visible = false
+	menu_state = MenuState.ITEM_SCREEN
+	if _player:
+		var items = _player.get_player_state().inventory.read_items()
+		item_menu_selected.emit(
+			items.get(0),
+			items.get(1),
+			items.get(2),
+			#items[0] if items.size() > 0 else "",
+			#items[1] if items.size() > 1 else "",
+			#items[2] if items.size() > 2 else ""
+		)
 
 func _sync_player_state() -> void:
 	if _player:
 		await _player.sync_player_state()
-		
+
 func _exit_menu() -> void:
 	menu.visible = false
 	menu_state = MenuState.NOTHING
-	GameManager.unlock_movement(&"menu")	
+	GameManager.unlock_movement(&"menu")
 
 func _handle_menu_select() -> void:
 	match selected_option:
@@ -81,7 +81,7 @@ func _handle_menu_select() -> void:
 			_exit_menu()
 		MenuOptions.EXIT:
 			_exit_menu()
-			
+
 func _unhandled_input(event: InputEvent) -> void:
 	match menu_state:
 		MenuState.NOTHING:
@@ -110,11 +110,12 @@ func _unhandled_input(event: InputEvent) -> void:
 
 		MenuState.STATUS_SCREEN:
 			if event.is_action_pressed("toggle_menu"):
-				if _stats_sub_menu:
-					_stats_sub_menu.queue_free()
-					_stats_sub_menu = null
+				status_menu_closed.emit()
 				menu.visible = true
 				menu_state = MenuState.MENU
 
 		MenuState.ITEM_SCREEN:
-			pass
+			if event.is_action_pressed("toggle_menu"):
+				item_menu_closed.emit()
+				menu.visible = true
+				menu_state = MenuState.MENU

--- a/scenes/menu.tscn
+++ b/scenes/menu.tscn
@@ -4,38 +4,47 @@
 [ext_resource type="Texture2D" uid="uid://b5alcyi8ki0om" path="res://assets/menu/menu_box_1.png" id="1_yqeox"]
 [ext_resource type="FontFile" uid="uid://dorfha5ylmpy8" path="res://assets/menu/pkmnfl.ttf" id="2_vjb58"]
 [ext_resource type="Texture2D" uid="uid://ducfduejpcjhd" path="res://assets/menu/ui_arrow_left_right.png" id="4_4ytvr"]
+[ext_resource type="PackedScene" uid="uid://bt37ga2qwtju0" path="res://scenes/ui/stats_sub_menu.tscn" id="5_statsmenu"]
+[ext_resource type="PackedScene" uid="uid://dem3lyc2k70ak" path="res://scenes/ui/items_sub_menu.tscn" id="6_itemsmenu"]
 
-[node name="Menu" type="Node2D" unique_id=1641783459]
+[node name="Menu" type="CanvasLayer" unique_id=1641783459]
+scale = Vector2(1.5, 1.5)
+transform = Transform2D(1.5, 0, 0, 1.5, 0, 0)
 script = ExtResource("1_mhnvy")
 
-[node name="Control" type="Control" parent="." unique_id=829471229]
+[node name="MainMenu" type="Control" parent="." unique_id=829471229]
 layout_mode = 3
 anchors_preset = 0
-offset_left = -56.0
-offset_top = -40.0
-offset_right = -5.0
-offset_bottom = 24.0
+offset_left = 1.0
+offset_top = 2.0
+offset_right = 51.0
+offset_bottom = 66.0
 
-[node name="MenuBanner" type="NinePatchRect" parent="Control" unique_id=1822370850]
+[node name="MenuBanner" type="NinePatchRect" parent="MainMenu" unique_id=1822370850]
 layout_mode = 0
-offset_left = -9.0
-offset_top = 3.0
-offset_right = 42.0
-offset_bottom = 70.0
+offset_left = -1.0
+offset_top = -2.0
+offset_right = 52.0
+offset_bottom = 67.0
 texture = ExtResource("1_yqeox")
 patch_margin_left = 6
 patch_margin_top = 6
 patch_margin_right = 6
 patch_margin_bottom = 6
 
-[node name="TextContainer" type="VBoxContainer" parent="Control/MenuBanner" unique_id=436584621]
-layout_mode = 0
+[node name="TextContainer" type="VBoxContainer" parent="MainMenu/MenuBanner" unique_id=436584621]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.054545455
+anchor_right = 0.12727273
+anchor_bottom = 0.39999998
 offset_left = 14.0
 offset_top = 8.0
 offset_right = 45.0
 offset_bottom = 66.0
+metadata/_edit_use_anchors_ = true
 
-[node name="StatusText" type="RichTextLabel" parent="Control/MenuBanner/TextContainer" unique_id=1509437999]
+[node name="StatusText" type="RichTextLabel" parent="MainMenu/MenuBanner/TextContainer" unique_id=1509437999]
 custom_minimum_size = Vector2(10, 10)
 layout_mode = 2
 theme_override_colors/default_color = Color(0.43529412, 0.43529412, 0.53333336, 1)
@@ -44,7 +53,7 @@ theme_override_font_sizes/normal_font_size = 10
 text = "STATS"
 justification_flags = 161
 
-[node name="ItemsText" type="RichTextLabel" parent="Control/MenuBanner/TextContainer" unique_id=1812079777]
+[node name="ItemsText" type="RichTextLabel" parent="MainMenu/MenuBanner/TextContainer" unique_id=1812079777]
 custom_minimum_size = Vector2(10, 10)
 layout_mode = 2
 theme_override_colors/default_color = Color(0.43529412, 0.43529412, 0.53333336, 1)
@@ -53,7 +62,7 @@ theme_override_font_sizes/normal_font_size = 10
 text = "ITEMS"
 justification_flags = 161
 
-[node name="SyncText" type="RichTextLabel" parent="Control/MenuBanner/TextContainer" unique_id=528600108]
+[node name="SyncText" type="RichTextLabel" parent="MainMenu/MenuBanner/TextContainer" unique_id=528600108]
 custom_minimum_size = Vector2(10, 10)
 layout_mode = 2
 theme_override_colors/default_color = Color(0.43529412, 0.43529412, 0.53333336, 1)
@@ -62,7 +71,7 @@ theme_override_font_sizes/normal_font_size = 10
 text = "SYNC"
 justification_flags = 161
 
-[node name="ExitText" type="RichTextLabel" parent="Control/MenuBanner/TextContainer" unique_id=597290111]
+[node name="ExitText" type="RichTextLabel" parent="MainMenu/MenuBanner/TextContainer" unique_id=597290111]
 custom_minimum_size = Vector2(10, 10)
 layout_mode = 2
 theme_override_colors/default_color = Color(0.43529412, 0.43529412, 0.53333336, 1)
@@ -71,10 +80,14 @@ theme_override_font_sizes/normal_font_size = 10
 text = "EXIT"
 justification_flags = 161
 
-[node name="TextureRect" type="TextureRect" parent="Control/MenuBanner" unique_id=1342418791]
+[node name="TextureRect" type="TextureRect" parent="MainMenu/MenuBanner" unique_id=1342418791]
 layout_mode = 0
-offset_left = 6.0
+offset_left = 8.0
 offset_top = 7.0
-offset_right = 13.0
+offset_right = 15.0
 offset_bottom = 17.0
 texture = ExtResource("4_4ytvr")
+
+[node name="StatsSubMenu" parent="." unique_id=1419528140 instance=ExtResource("5_statsmenu")]
+
+[node name="ItemsSubMenu" parent="." unique_id=1684892213 instance=ExtResource("6_itemsmenu")]

--- a/scenes/scripts/inventory.gd
+++ b/scenes/scripts/inventory.gd
@@ -2,9 +2,9 @@ class_name Inventory
 extends Resource
 
 const _VALID_ITEMS = ["magic wand", "door key"]
-const _MAX_SIZE = 4
+const _MAX_SIZE = 3
 
-var _items: Array = []
+var _items: Array[String] = []
 
 func _init(items: Array[String] = []):
 	for item in items:
@@ -26,7 +26,7 @@ func load_items(items: Array[String]):
 		_items.append(valid_item)
 
 
-func read_items():
+func read_items() -> Array[String]:
 	return _items
 
 func has_item(item) -> bool:

--- a/scenes/ui/items_sub_menu.gd
+++ b/scenes/ui/items_sub_menu.gd
@@ -1,0 +1,24 @@
+extends CanvasLayer
+
+@onready var item1_text: RichTextLabel = $ItemsMenu/TextContainer/Item1Text
+@onready var item2_text: RichTextLabel = $ItemsMenu/TextContainer/Item2Text
+@onready var item3_text: RichTextLabel = $ItemsMenu/TextContainer/Item3Text
+func _ready() -> void:
+	visible = false
+
+func get_longest_text_string(s_array: Array) -> int:
+	return s_array.map(func(s): return len(s)).max()
+	
+func _on_item_menu_selected(item1: Variant, item2: Variant, item3: Variant) -> void:
+	visible = true
+	var item_array: Array[Variant] = [item1, item2, item3]
+	var longest_string_length: int = get_longest_text_string(item_array.filter(func(v): return v != null))
+	_update_items(item_array.map((func(v): return v.to_upper() if v != null else "-".repeat(longest_string_length))))
+
+func _on_item_menu_closed() -> void:
+	visible = false
+
+func _update_items(item_array: Array) -> void:
+	item1_text.text = item_array[0]
+	item2_text.text = item_array[1]
+	item3_text.text = item_array[2]

--- a/scenes/ui/items_sub_menu.gd.uid
+++ b/scenes/ui/items_sub_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://d1agt4iaw0n7

--- a/scenes/ui/items_sub_menu.tscn
+++ b/scenes/ui/items_sub_menu.tscn
@@ -1,0 +1,67 @@
+[gd_scene format=3 uid="uid://dem3lyc2k70ak"]
+
+[ext_resource type="Texture2D" uid="uid://b5alcyi8ki0om" path="res://assets/menu/menu_box_1.png" id="1_dlhxm"]
+[ext_resource type="Script" uid="uid://d1agt4iaw0n7" path="res://scenes/ui/items_sub_menu.gd" id="1_items"]
+[ext_resource type="FontFile" uid="uid://dorfha5ylmpy8" path="res://assets/menu/pkmnfl.ttf" id="2_items"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_1"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+texture = ExtResource("1_dlhxm")
+texture_margin_left = 6.0
+texture_margin_top = 6.0
+texture_margin_right = 7.0
+texture_margin_bottom = 6.0
+axis_stretch_horizontal = 1
+
+[node name="ItemsSubMenu" type="CanvasLayer" unique_id=1824426790]
+scale = Vector2(1.5, 1.5)
+transform = Transform2D(1.5, 0, 0, 1.5, 0, 0)
+script = ExtResource("1_items")
+
+[node name="ItemsMenu" type="PanelContainer" parent="." unique_id=2045396155]
+theme_override_styles/panel = SubResource("StyleBoxTexture_1")
+
+[node name="TextContainer" type="VBoxContainer" parent="ItemsMenu" unique_id=1508734366]
+layout_mode = 2
+
+[node name="Item1Text" type="RichTextLabel" parent="ItemsMenu/TextContainer" unique_id=1799211575]
+custom_minimum_size = Vector2(10, 10)
+layout_mode = 2
+localize_numeral_system = false
+theme_override_colors/default_color = Color(0.43529412, 0.43529412, 0.53333336, 1)
+theme_override_fonts/normal_font = ExtResource("2_items")
+theme_override_font_sizes/normal_font_size = 10
+text = "Item 1"
+fit_content = true
+autowrap_mode = 0
+vertical_alignment = 1
+justification_flags = 161
+
+[node name="Item2Text" type="RichTextLabel" parent="ItemsMenu/TextContainer" unique_id=126555813]
+custom_minimum_size = Vector2(10, 10)
+layout_mode = 2
+localize_numeral_system = false
+theme_override_colors/default_color = Color(0.43529412, 0.43529412, 0.53333336, 1)
+theme_override_fonts/normal_font = ExtResource("2_items")
+theme_override_font_sizes/normal_font_size = 10
+text = "Item 2"
+fit_content = true
+autowrap_mode = 0
+vertical_alignment = 1
+justification_flags = 161
+
+[node name="Item3Text" type="RichTextLabel" parent="ItemsMenu/TextContainer" unique_id=1018265855]
+custom_minimum_size = Vector2(10, 10)
+layout_mode = 2
+localize_numeral_system = false
+theme_override_colors/default_color = Color(0.43529412, 0.43529412, 0.53333336, 1)
+theme_override_fonts/normal_font = ExtResource("2_items")
+theme_override_font_sizes/normal_font_size = 10
+text = "Item 3"
+fit_content = true
+autowrap_mode = 0
+vertical_alignment = 1
+justification_flags = 161

--- a/scenes/ui/stats_sub_menu.gd
+++ b/scenes/ui/stats_sub_menu.gd
@@ -1,21 +1,20 @@
-extends Node2D
+extends CanvasLayer
 
-@onready var hp_text: RichTextLabel = $Control/StatsMenu/TextContainer/HPText
-@onready var atk_text: RichTextLabel = $Control/StatsMenu/TextContainer/ATKText
-@onready var def_text: RichTextLabel = $Control/StatsMenu/TextContainer/DEFText
-
-var _player: Player
+@onready var hp_text: RichTextLabel = $StatsMenu/TextContainer/HPText
+@onready var atk_text: RichTextLabel = $StatsMenu/TextContainer/ATKText
+@onready var def_text: RichTextLabel = $StatsMenu/TextContainer/DEFText
 
 func _ready() -> void:
-	_player = get_tree().get_first_node_in_group("player_group")
-	if _player:
-		_player.sync_player_completed.connect(_on_sync_success)
-		_update_stats(_player.get_player_state())
+	visible = false
 
-func _update_stats(state: PlayerState) -> void:
-	hp_text.text = "HP: %d" % state.stats.x
-	atk_text.text = "ATK: %d" % state.stats.y
-	def_text.text = "DEF: %d" % state.stats.z
+func _on_status_menu_selected(hp: int, atk: int, def: int) -> void:
+	visible = true
+	_update_stats(hp, atk, def)
 
-func _on_sync_success() -> void:
-	_update_stats(_player.get_player_state())
+func _on_status_menu_closed() -> void:
+	visible = false
+
+func _update_stats(hp: int, atk: int, def: int) -> void:
+	hp_text.text = "HP: %d" % hp
+	atk_text.text = "ATK: %d" % atk
+	def_text.text = "DEF: %d" % def

--- a/scenes/ui/stats_sub_menu.tscn
+++ b/scenes/ui/stats_sub_menu.tscn
@@ -1,42 +1,33 @@
-[gd_scene format=3 uid="uid://b4y1sjmta77j7"]
+[gd_scene format=3 uid="uid://bt37ga2qwtju0"]
 
 [ext_resource type="Script" uid="uid://b22hifjdogtdp" path="res://scenes/ui/stats_sub_menu.gd" id="1_bobfa"]
 [ext_resource type="Texture2D" uid="uid://b5alcyi8ki0om" path="res://assets/menu/menu_box_1.png" id="1_dlhxm"]
 [ext_resource type="FontFile" uid="uid://dorfha5ylmpy8" path="res://assets/menu/pkmnfl.ttf" id="2_bobfa"]
 
-[node name="StatsSubMenu" type="Node2D" unique_id=79107404]
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_1"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+texture = ExtResource("1_dlhxm")
+texture_margin_left = 6.0
+texture_margin_top = 6.0
+texture_margin_right = 7.0
+texture_margin_bottom = 6.0
+axis_stretch_horizontal = 1
+
+[node name="StatsSubMenu" type="CanvasLayer" unique_id=79107404]
+scale = Vector2(1.5, 1.5)
+transform = Transform2D(1.5, 0, 0, 1.5, 0, 0)
 script = ExtResource("1_bobfa")
 
-[node name="Control" type="Control" parent="." unique_id=38661780]
-layout_mode = 3
-anchors_preset = 0
-offset_left = -56.0
-offset_top = -40.0
-offset_right = -5.0
-offset_bottom = 24.0
+[node name="StatsMenu" type="PanelContainer" parent="." unique_id=1488263814]
+theme_override_styles/panel = SubResource("StyleBoxTexture_1")
 
-[node name="StatsMenu" type="NinePatchRect" parent="Control" unique_id=1488263814]
-layout_mode = 0
-offset_left = -9.0
-offset_top = 4.0
-offset_right = 49.0
-offset_bottom = 61.0
-texture = ExtResource("1_dlhxm")
-patch_margin_left = 6
-patch_margin_top = 6
-patch_margin_right = 7
-patch_margin_bottom = 6
-axis_stretch_horizontal = 1
-metadata/_edit_group_ = true
+[node name="TextContainer" type="VBoxContainer" parent="StatsMenu" unique_id=1028223399]
+layout_mode = 2
 
-[node name="TextContainer" type="VBoxContainer" parent="Control/StatsMenu" unique_id=1028223399]
-layout_mode = 0
-offset_left = 8.0
-offset_top = 8.0
-offset_right = 48.0
-offset_bottom = 66.0
-
-[node name="HPText" type="RichTextLabel" parent="Control/StatsMenu/TextContainer" unique_id=103142522]
+[node name="HPText" type="RichTextLabel" parent="StatsMenu/TextContainer" unique_id=103142522]
 custom_minimum_size = Vector2(10, 10)
 layout_mode = 2
 localize_numeral_system = false
@@ -49,7 +40,7 @@ autowrap_mode = 0
 vertical_alignment = 1
 justification_flags = 161
 
-[node name="ATKText" type="RichTextLabel" parent="Control/StatsMenu/TextContainer" unique_id=2025703081]
+[node name="ATKText" type="RichTextLabel" parent="StatsMenu/TextContainer" unique_id=2025703081]
 custom_minimum_size = Vector2(10, 10)
 layout_mode = 2
 localize_numeral_system = false
@@ -62,7 +53,7 @@ autowrap_mode = 0
 vertical_alignment = 1
 justification_flags = 161
 
-[node name="DEFText" type="RichTextLabel" parent="Control/StatsMenu/TextContainer" unique_id=982701455]
+[node name="DEFText" type="RichTextLabel" parent="StatsMenu/TextContainer" unique_id=982701455]
 custom_minimum_size = Vector2(10, 10)
 layout_mode = 2
 localize_numeral_system = false


### PR DESCRIPTION
This PR addresses the following
1. [Feature] Add Item sub-menu, displays up to maximum number of items (3)
2. [Refactor] Change root node of menu to CanvasLayer so that menus are automatically anchored to screen space. 
3. [Refactor] Change how menus communicate with one another. 
    - Menu and sub-menu are contained within same scene, with sub-menus being invisible at launch. Signals sent by menu are used to toggle sub-menu visibility.
    - Menu will pass sub-menus the values to display through signals. This keeps logic for data retrieval and calculation within the main menu script. 
